### PR TITLE
[이코테/01] ByeongJun

### DIFF
--- a/CT-DongbinNa/ByeongJun/PART02/p115_구현_실전2_왕실의 나이트.py
+++ b/CT-DongbinNa/ByeongJun/PART02/p115_구현_실전2_왕실의 나이트.py
@@ -1,0 +1,19 @@
+pos = input()
+
+col = ord(pos[0]) - 96 # 열
+row = int(pos[1]) # 행
+
+move = [[1, 2], [1, -2], [2, 1], [2, -1],
+        [-1, -2], [-1, 2], [-2, -1], [-2, 1]]
+
+pos = [col, row]
+
+count = 0
+
+for i in range(8):
+    if col + move[i][0] > 8 or col + move[i][0] < 1 or row + move[i][1] > 8 or row + move[i][1] < 1:
+        continue
+    count += 1
+
+print(count)
+# ord A = 65 a = 97

--- a/CT-DongbinNa/ByeongJun/PART02/p118_구현_실전3_게임 개발.py
+++ b/CT-DongbinNa/ByeongJun/PART02/p118_구현_실전3_게임 개발.py
@@ -1,0 +1,45 @@
+N, M = map(int, input().split())
+A, B, d = map(int, input().split())
+
+# 북 동 남 서
+dx = [-1, 0, 1, 0]
+dy = [0, 1, 0, -1]
+
+# N*M 크기의 지도 생성
+maps = []
+for i in range(N):
+    maps.append(list(map(int, input().split())))
+
+# visited = []
+# for i in range(M):
+#     for j in range(N):
+#         visited[M][N] = False
+visited = [[False] * M for _ in range(N)] # 리스트 컴프리헨션
+
+count = 1 # 초기 위치 카운트
+visited[A][B] = True # 초기 위해 방문
+
+while True:
+    for _ in range(4):
+        d = (d - 1) % 4 # 마이너스 인덱스를 이용하여 왼쪽 방향 전환
+        nx = A + dx[d] # 방문할 x좌표
+        ny = B + dy[d] # 방문할 y좌표
+
+        # 왼쪽 방향에 가보지 않은 육지가 있으면 이동
+        if not visited[nx][ny] and maps[nx][ny] == 0:
+            visited[nx][ny] = True
+            A = nx
+            B = ny
+            count += 1
+            break
+    else: # for-else문을 통해 break 시에 실행되지 않도록 함(네 방향 모두 갈 수 없는 경우)
+        back_x = A - dx[d]
+        back_y = B - dy[d]
+
+        if maps[back_x][back_y] == 1: # 뒤가 바다인 경우 종료
+            break
+        else: # 뒤로 한 칸 이동
+            A = back_x
+            B = back_y
+
+print(count)

--- a/CT-DongbinNa/ByeongJun/PART02/p92_그리디_실전2_큰 수의 법칙.py
+++ b/CT-DongbinNa/ByeongJun/PART02/p92_그리디_실전2_큰 수의 법칙.py
@@ -1,0 +1,18 @@
+N, M, K = map(int, input().split())
+
+numbers = list(map(int, input().split()))
+
+numbers.sort(reverse=True) # 크기 내림차순 정렬
+
+result = 0
+i = 0
+
+for _ in range(M):
+    if i >= K:
+        result += numbers[1]
+        i = 0
+    else:
+        result += numbers[0]
+        i += 1
+
+print(result)

--- a/CT-DongbinNa/ByeongJun/PART02/p96_그리디_실전3_숫자 카드 게임.py
+++ b/CT-DongbinNa/ByeongJun/PART02/p96_그리디_실전3_숫자 카드 게임.py
@@ -1,0 +1,13 @@
+N, M = map(int, input().split()) # N행, M열
+
+cards = [] # 리스트 선언
+
+answer = 0
+
+for i in range(N): # N개의 줄에 걸쳐 입력받기
+    cards.append(list(map(int, input().split()))) # 2차원 리스트
+    cards[i].sort()
+    if answer < cards[i][0]:
+        answer = cards[i][0]
+
+print(answer)

--- a/CT-DongbinNa/ByeongJun/PART02/p99_그리디_실전4_1이 될 때까지.py
+++ b/CT-DongbinNa/ByeongJun/PART02/p99_그리디_실전4_1이 될 때까지.py
@@ -1,0 +1,12 @@
+N, K = map(int, input().split())
+
+count = 0
+
+while N != 1:
+    if N % K == 0:
+        N //= K
+    else:
+        N -= 1
+    count += 1
+
+print(count)


### PR DESCRIPTION
## 📖 풀이한 문제
1. 나동빈 이코테 92p 큰 수의 법칙
2. 나동빈 이코테 96p 숫자 카드 게임
3. 나동빈 이코테 99p 1이 될 때까지
4. 나동빈 이코테 115p 왕실의 나이트
5. 나동빈 이코테 118p 게임 개발

## 💡 문제에서 사용된 알고리즘
1. 그리디(큰 수의 법칙, 숫자 카드 게임, 1이 될  때까지)
2. 구현(왕실의 나이트, 게임 개발)

## 📜 코드 설명
**1. 나동빈 이코테 92p 큰 수의 법칙**
- 큰 수에 법칙에 따르면 이루어진 배열에서 1, 2번째로 큰 값들만 서로 더해지는 것을 알 수 있으므로 배열을 크기대로 내림차순 정렬을 수행함.
- 두 가지 연산만이 필요하므로 조건문을 통해 분기 연산을 수행함.

**2. 나동빈 이코테 96p 숫자 카드 게임**
- 가장 큰 수를 찾는 것이 목표이기 때문에 정렬을 통해 최댓값을 갱신하는 방식으로 수행

**3. 나동빈 이코테 99p 1이 될 때까지**
- 1이 될 때까지 연산을 수행해야 하므로 while문의 조건을 1이 아닐 때까지로 설정
- 나누어 떨어질 때는 나누고, 나누어 떨어지지 않을 때는 -1을 하도록 두 가지 연산을 통해 분기 연산을 수행함.

**4. 나동빈 이코테 115p 왕실의 나이트**
- 열이 알파벳으로 주어지기 때문에 체스판의 특성상 숫자 x 숫자 형태로 나타내기 위해 ord() 함수를 사용해 해당하는 아스키 코드표의 숫자로 변환하여 96을 뺌.
- 나이트의 특성 상 이동할 수 잇는 경우를 미리 모두 정의하고 해당 경우가 총 8가지이므로 나이트의 위치를 기준으로 연산을 수행해 실제로 이동이 가능한지 반복문과 조건문을 통해 판단

**5. 나동빈 이코테 118p 게임 개발**
- 리스트 컴프리헨션을 통해 방문 여부 리스트 초기화
- 파이썬에서 마이너스 인덱스가 가능하다는 점을 이용해서 왼쪽 방향 전환 로직을 % 연산자로 수행함
- 유저의 이동 횟수는 처음에 시작하는 위치와 가보지 않은 육지가 보장되는 경우에 만 증가하도록 구현함
- for-else문을 통해 네 방향으로 모두 갈 수 없는 경우를 설정함