### PR TITLE
[이코테/02] ChaeRim

### DIFF
--- a/CT-DongbinNa/ChaeRim/part2_DFS&BFS_미로 탈출.py
+++ b/CT-DongbinNa/ChaeRim/part2_DFS&BFS_미로 탈출.py
@@ -1,0 +1,29 @@
+from collections import deque
+global dq
+dq = deque()
+N,M = map(int,input().split())
+
+board = []
+for _ in range(N):
+    board.append(list(map(int,input())))
+
+#상하좌우
+dx = [0,0,-1,1]
+dy = [-1,1,0,0]
+
+def bfs(y,x):
+    dq.append((y,x))
+    while dq:
+        y,x = dq.popleft()
+        for i in range(4):
+            ny, nx = y+dy[i], x+dx[i]
+            if nx < 0 or ny < 0 or nx >= M or ny >= N:
+                continue
+            if board[ny][nx] == 0:
+                continue
+            if board[ny][nx] == 1: #첫 방문 기록
+                dq.append((ny,nx))
+                board[ny][nx] = board[y][x] + 1
+
+    return board[N-1][M-1] #반드시 탈출가능한 형태로 준다 함
+print(bfs(0,0))

--- a/CT-DongbinNa/ChaeRim/part2_DFS&BFS_미로 탈출.py
+++ b/CT-DongbinNa/ChaeRim/part2_DFS&BFS_미로 탈출.py
@@ -1,29 +1,28 @@
 from collections import deque
-global dq
 dq = deque()
-N,M = map(int,input().split())
+n, m = map(int, input().split())
 
-board = []
-for _ in range(N):
-    board.append(list(map(int,input())))
+board = [input().rstrip() for _ in range(n)]
+visited = [[0]*m for _ in range(n)]
 
-#상하좌우
-dx = [0,0,-1,1]
-dy = [-1,1,0,0]
+dx = [-1, 1, 0, 0]
+dy = [0, 0, -1, 1]
 
-def bfs(y,x):
-    dq.append((y,x))
-    while dq:
-        y,x = dq.popleft()
-        for i in range(4):
-            ny, nx = y+dy[i], x+dx[i]
-            if nx < 0 or ny < 0 or nx >= M or ny >= N:
-                continue
-            if board[ny][nx] == 0:
-                continue
-            if board[ny][nx] == 1: #첫 방문 기록
-                dq.append((ny,nx))
-                board[ny][nx] = board[y][x] + 1
+dq.append((0,0))
+visited[0][0] = 1
 
-    return board[N-1][M-1] #반드시 탈출가능한 형태로 준다 함
-print(bfs(0,0))
+while dq:
+    x, y = dq.popleft()
+
+    if x == n-1 and y == m-1: # 마지막 좌표라면 !
+        print(visited[x][y])
+        break
+
+    for i in range(4):
+        # 다음 방문 확인
+        nx = x + dx[i]
+        ny = y + dy[i]
+        if 0 <= nx < n and 0 <= ny < m: # 범위 내에 있다면
+            if visited[nx][ny] == 0 and board[nx][ny] == '1': # 방문안했고, 입력받은 맵이 1이라면
+                visited[nx][ny] = visited[x][y] +1 # 누적
+                dq.append((nx,ny))

--- a/CT-DongbinNa/ChaeRim/part2_DFS&BFS_음료수 얼려 먹기.py
+++ b/CT-DongbinNa/ChaeRim/part2_DFS&BFS_음료수 얼려 먹기.py
@@ -1,0 +1,27 @@
+from collections import deque
+N,M = map(int,input().split())
+ice = []
+cnt = 0 #얼음 개수
+#visited = [[False]*M for _ in range(N)]
+
+for i in range(N):
+    ice.append(list(map(int,input())))
+
+def dfs(y,x):
+    if x < 0 or x >= M or y < 0 or y >= N: #범위검사
+        return False
+    if ice[y][x] == 0:
+        ice[y][x] = 1 #방문처리
+        dfs(y-1,x) #상
+        dfs(y+1,x) #하
+        dfs(y,x-1) #좌
+        dfs(y,x+1) #우
+        return True
+    else:
+        return False
+
+for i in range(N):
+    for j in range(M):
+        if dfs(i,j):
+            cnt += 1
+print(cnt)

--- a/CT-DongbinNa/ChaeRim/part2_정렬_두 배열의 원소 교체.py
+++ b/CT-DongbinNa/ChaeRim/part2_정렬_두 배열의 원소 교체.py
@@ -1,0 +1,15 @@
+import sys
+input = sys.stdin.readline
+
+N,K=map(int,input().split())
+A = list(map(int,input().split()))
+B = list(map(int,input().split()))
+
+A.sort()
+B.sort(reverse=True)
+
+for i in range(K):
+    if A[i] < B[i]:A[i],B[i] = B[i],A[i]
+    else: break
+
+print(sum(A))

--- a/CT-DongbinNa/ChaeRim/part2_정렬_성적이 낮은 순서로 학생 출력하기.py
+++ b/CT-DongbinNa/ChaeRim/part2_정렬_성적이 낮은 순서로 학생 출력하기.py
@@ -1,0 +1,11 @@
+N=int(input())
+li = []
+for _ in range(N):
+    name, score = map(str,input().split())
+    score = int(score)
+    li.append((name,score))
+
+li.sort(key=lambda x : x[1]) #점수 기준 정렬
+
+for i in li:
+    print(i[0], end=" ")

--- a/CT-DongbinNa/ChaeRim/part2_정렬_위에서 아래로.py
+++ b/CT-DongbinNa/ChaeRim/part2_정렬_위에서 아래로.py
@@ -1,0 +1,7 @@
+N=int(input())
+li = []
+for _ in range(N):
+    li.append(int(input()))
+
+li.sort(reverse=True)
+print(*li)


### PR DESCRIPTION
**📖 풀이한 문제**
[이코테 Part2 05,06 실전문제]
1. 음료수 얼려 먹기
2. 미로 탈출
3. 위에서 아래로
4. 성적이 낮은 순서로 학생 출력하기
5. 두 배열의 원소 교체

**💡 문제에서 사용된 알고리즘**
1. DFS/BFS
2. 정렬


**📜 코드 설명**

**1. 음료수 얼려먹기**
- 배열로 입력을 받아 ice인 영역까지 깊이 우선 탐색을 진행한다.
- dfs 함수는 범위 검사 후, 각 y,x좌표로 상하좌우를 재귀적으로 탐색한 후 방문처리를 진행한다. 
- 0에서 시작해서 돌다가 방문할 수 없는 1에 도달하면 False를 반환, 얼음 개수 cnt += 1을 해준다.

**2. 미로 탈출**
- deque를 선언한다. 리스트에 입력을 받고, dx, dy를 설정해준다.
- 일단 첫 시작지점인 0,0 좌표를 dq에 넣는다. 방문 체크 리스트도 방문했다고 체크한다.
- dq가 비지않을 때까지, (x,y)를 빼고 상하좌우 방문 탐색을해 방문 가능하면 누적되는 만큼 개수를 누적하고 dq에 넣어주자. 
- 마지막 좌표라면 출력하고 반복문 탈출

**3. 위에서 아래로**
- 리스트로 입력받아, 내림차순으로 정렬하고 원소 출력해주면 끝이다. 
- 반복문 안쓰고 대괄호 없이, 리스트 원소 한 줄 출력 하고 싶어서 `*(Asterisk)`를 사용했다. 
- `print(*sorted(li))`처럼 응용할 수도 있다고 한다. 파이썬 리스트는 `Asterisk`를 사용하면 리스트 압축 해제가 가능하다. 

**4. 성적이 낮은 순서로 학생 출력하기**
- 리스트로 입력받아 name과 score를 튜플 형태로 추가한다. 그리고 `lambda`를 사용하여 `score`을 기준으로 정렬한다. 
- 리스트안에 튜플에서 0번째 요소인 이름만 출력한다.

**5. 두 배열의 원소교체**
- A는 오름차순, B는 내림차순으로 정렬해주고 원소 개수가 같으니
- A의 요소 < B의 요소일 때만 swap해준다. 그 후 sum함수로 결과를 출력한다.