### PR TITLE
[이코테/04] ByeongJun

### DIFF
--- a/CT-DongbinNa/ByeongJun/PART02/p259_최단경로_실전2_미래 도시.py
+++ b/CT-DongbinNa/ByeongJun/PART02/p259_최단경로_실전2_미래 도시.py
@@ -1,0 +1,30 @@
+INF = int(1e9)
+
+N, M = map(int, input().split()) # N = 회사의 개수, M = 경로의 개수
+graph = [[INF] * (N+1) for _ in range(N+1)]
+
+for a in range(1, N+1):
+    for b in range(1, N+1):
+        if a==b:
+            graph[a][b] = 0
+
+for _ in range(M):
+    a, b = map(int, input().split())
+    graph[a][b] = 1
+    graph[b][a] = 1
+
+X, K = map(int, input().split()) # X = 최종 회사, K = 소개팅 회사
+
+result = -1
+
+for k in range(1, N + 1):
+    for a in range(1, N + 1):
+        for b in range(1, N + 1):
+            graph[a][b] = min(graph[a][b], graph[a][k] + graph[k][b])
+            if a==1 and k==K and b==X: # 시작이 1, 거쳐가는 k, 도착하는 b
+                result = graph[a][k] + graph[k][b]
+
+if result >= INF:
+    print(-1)
+else:
+    print(result)

--- a/CT-DongbinNa/ByeongJun/PART02/p262_최단경로_실전3_전보.py
+++ b/CT-DongbinNa/ByeongJun/PART02/p262_최단경로_실전3_전보.py
@@ -1,0 +1,43 @@
+import heapq
+import sys
+input = sys.stdin.readline
+INF = int(1e9)
+
+N, M, C = map(int, input().split())
+
+start = C
+graph = [[] for i in range(N + 1)]
+distance = [INF] * (N + 1)
+
+for _ in range(M):
+    X, Y, Z = map(int, input().split())
+    graph[X].append((Y, Z))
+
+def dijkstra(start):
+    q = []
+    heapq.heappush(q, (0, start)) # 자기 자신으로 가는 비용은 0
+    distance[start] = 0
+    while q:
+        dist, now = heapq.heappop(q)
+        if distance[now] < dist:
+            continue
+        for i in graph[now]:
+            cost = dist + i[1]
+            if cost < distance[i[0]]:
+                distance[i[0]] = cost
+                heapq.heappush(q, (cost, i[0]))
+
+dijkstra(start)
+
+total_city = 0
+total_time = 0
+
+for i in range(1, N + 1):
+    if distance[i] == INF or i == start:
+        continue
+    total_time = max(total_time, distance[i])
+    total_city += 1
+
+print(f"{total_city} {total_time}")
+
+# 모두 메시지를 받는다는 것의 의미가 총 걸리는 시간이 아니라 마지막에 받은 시간을 의미함.

--- a/CT-DongbinNa/ByeongJun/PART02/p298_그래프이론_실전2_팀 결성.py
+++ b/CT-DongbinNa/ByeongJun/PART02/p298_그래프이론_실전2_팀 결성.py
@@ -1,0 +1,38 @@
+# 0 a b: a 학생 팀과 b 학생 팀 union
+# 1 a b: a 학생과 b 학생이 같은 팀인지 find
+# 1 a b에 대해서 YES or NO 출력
+
+def find(parent, x):
+    if parent[x] != x:
+        parent[x] = find(parent, parent[x]) # parent 인자는 parent 리스트를 넘기기 위해, parent[x]는 root까지 가기 위한 현재 노드
+    return parent[x]
+
+def union(parent, a, b):
+    a = find(parent, a)
+    b = find(parent, b)
+    if a < b:
+        parent[b] = a
+    else:
+        parent[a] = b
+
+N, M = map(int, input().split())
+parent = [0] * (M + 1)
+results = []
+
+for i in range(1, M + 1):
+    parent[i] = i
+
+for i in range(M):
+    operation, a, b = map(int, input().split())
+    if operation == 0:
+        union(parent, a, b)
+    else:
+        root_a = find(parent, a)
+        root_b = find(parent, b)
+        if root_a == root_b:
+            results.append('YES')
+        else:
+            results.append('NO')
+
+for result in results:
+    print(result)

--- a/CT-DongbinNa/ByeongJun/PART02/p300_그래프이론_실전3_도시 분할 계획.py
+++ b/CT-DongbinNa/ByeongJun/PART02/p300_그래프이론_실전3_도시 분할 계획.py
@@ -1,0 +1,42 @@
+# 길은 어느 방향이로든지 다닐 수 있다 = 양방향
+# N개의 집과 집들을 연결하는 M개의 길 = 그래프 이론
+# 두 집 사이의 경로가 존재하면서 길을 없앨 수 있다 & 유지비의 합을 최소 = 크루스칼 최소 신장 트리 적용
+# 우선 크루스칼을 적용하여 minimum spanning tree를 하나 구하고, 가장 cost가 큰 간선 제거 시 유지비를 최소로 하면서 2개로 분할 가능
+def find(parent, x):
+    if parent[x] != x:
+        parent[x] = find(parent, parent[x])
+    return parent[x]
+
+def union(parent, a, b):
+    a = find(parent, a)
+    b = find(parent, b)
+    if a < b:
+        parent[b] = a
+    else:
+        parent[a] = b
+
+N, M = map(int, input().split())
+parent = [0] * (N + 1)
+cost = 0
+most_cost = 0
+for i in range(1, N + 1):
+    parent[i] = i
+
+edges = []
+
+for i in range(M):
+    A, B, C = map(int, input().split())
+    edges.append((C, A, B))
+
+edges.sort()
+
+for edge in edges:
+    C, A, B = edge
+    if find(parent, A) != find(parent, B):
+        union(parent, A, B)
+        cost += C
+        most_cost = C
+
+cost -= most_cost
+
+print(cost)

--- a/CT-DongbinNa/ByeongJun/PART02/p303_그래프이론_실전4_커리큘럼.py
+++ b/CT-DongbinNa/ByeongJun/PART02/p303_그래프이론_실전4_커리큘럼.py
@@ -1,0 +1,45 @@
+# 선후수 관계가 있으므로 위상 정렬을 사용해야 함
+# 동시에 강의 수강이 가능하므로, 예시에서 1번 강의와 2번 강의를 동시에 수강하고, 3번 강의 수강 시에 최소 70시간
+from collections import deque
+N = int(input()) # N: 강의의 수
+import copy
+
+indegree = [0] * (N + 1)
+time = [0] * (N + 1)
+# time_result = [0] * (N + 1) # 결과
+graph = [[] for i in range(N+1)]
+
+for i in range(1, N+1):
+    temp = list(map(int, input().split())) # 4 1 -1
+    time[i] = temp[0]
+    #for j in range(1, len(temp) + 1):
+    for j in temp[1:-1]:
+        #if temp[j] == -1:
+         #   break
+        indegree[i] += 1
+        graph[j].append(i)
+
+# indegree가 0이면 해당 시간 그대로 출력
+# indegree가 0 이상이면 선수 과목들 중 최대 시간 + 후수 과목 시간
+def topology_sort():
+    time_result = copy.deepcopy(time)
+    q = deque()
+
+    for i in range(1, N + 1):
+        if indegree[i] == 0:
+            q.append(i)
+
+    while q:
+        now = q.popleft()
+        # result.append(now)
+        for i in graph[now]:
+            time_result[i] = max(time_result[i], time_result[now] + time[i])
+            indegree[i] -= 1
+            if indegree[i] == 0:
+                q.append(i)
+
+    for i in time_result[1:len(time_result)+1]:
+        print(i)
+
+topology_sort()
+


### PR DESCRIPTION
## 📖 풀이한 문제
1. 나동빈 이코테 259p 미래 도시
2. 나동빈 이코테 262p 전보
3. 나동빈 이코테 298p 팀 결성
4. 나동빈 이코테 300p 도시 분할 계획
5. 나동빈 이코테 303p 커리큘럼

## 💡 문제에서 사용된 알고리즘
1. 최단경로(미래 도시, 전보)
2. 그래프 이론(팀 결성, 도시 분할 계획, 커리큘럼)

## 📜 코드 설명
**1. 나동빈 이코테 259p 미래 도시**
- 문제에서 주어진 조건에 따르면, 거쳐가는 회사가 있기 때문에 플로이드 워셜 알고리즘을 이용
- 결과가 INF보다 커질 수 있기 때문에 ">="로 조건 명시

**2. 나동빈 이코테 262p 전보**
- 문제 해석에 시간이 오래걸림 -> 모두 메시지를 받는다는 것의 의미가 총 걸리는 시간이 아니라 마지막에 받은 시간임
- 향상된 다익스트라 알고리즘을 사용해서 O(ElogV)의 시간으로 알고리즘 수행
- 잘린 떡의 길이를 다 더한 값이 타겟인 M 이상이면 절단기 높이 최신화

**3. 나동빈 이코테 298p 팀 결성**
- 결과를 리스트에 저장 후 마지막에 출력
- 예제와 크게 다르지 않음

**4. 나동빈 이코테 300p 도시 분할 계획**
- 길이 어느 방향이로든 가능하므로 양방향인 그래프 이론 사용
- 크루스칼을 적용하여 minimum spanning tree를 하나 구하고, 가장 cost가 큰 간선을 제거하여 2개를 생성함

**5. 나동빈 이코테 303p 커리큘럼**
- 1x2, 2x1, 2x2로 타일이 정의되어 있으므로 크기 2에 해당하는 i-1과 i-2만 고려
- dp_table[i-1]은 1x2를 고려, dp_table[i-2]는 2x1과 2x2를 고려함.
- dp_table[i-2]에서 1x2를 고려하지 않는 이유는 dp_table[i-1]에서 이미 산출되어 있기 때문

**6. 나동빈 이코테 226p 효율적인 화폐 구성**
- 선후수 관계가 있으므로 위상 정렬을 사용해야 함
- 리스트를 대입 형식으로 했다가 제대로 적용이 되지 않아서 시간을 날림 -> 답지에서 사용한 deepcopy 사용으로 리스트 복사 수행