### PR TITLE
[이코테/09] ChaeRim

### DIFF
--- a/CT-DongbinNa/ChaeRim/part3_국영수.py
+++ b/CT-DongbinNa/ChaeRim/part3_국영수.py
@@ -1,0 +1,18 @@
+import sys
+input = sys.stdin.readline
+
+def sorting(student):
+    # 내림차순은 음수 처리
+    li = sorted(a, key=lambda x: (-x[1],x[2],-x[3],x[0]))
+    for name in li:
+        print(name[0])
+
+N=int(input())
+a = []
+for _ in range(N):
+    name, k, e, m = map(str,input().split())
+    k,e,m = int(k),int(e),int(m)
+    a.append([name,k,e,m])
+
+sorting(a)
+

--- a/CT-DongbinNa/ChaeRim/part3_인구이동.py
+++ b/CT-DongbinNa/ChaeRim/part3_인구이동.py
@@ -1,0 +1,54 @@
+import sys
+input = sys.stdin.readline
+from collections import deque
+
+
+N,L,R = map(int,input().split())
+board = []
+dy = [-1,1,0,0]
+dx = [0,0,-1,1]
+
+for i in range(N):
+    board.append(list(map(int,input().split())))
+
+def checkVaild(i,j):
+    return 0 <= i < N and 0 <= j < N
+
+def bfs(i,j):
+    dq = deque()
+    dq.append((i,j))
+    union = [(i,j)]
+
+    while dq:
+        y,x = dq.popleft()
+        for i in range(4):
+            ny = y+ dy[i]
+            nx = x+ dx[i]
+            if checkVaild(ny,nx) and not visited[ny][nx] and L <= abs(board[ny][nx] - board[y][x]) <= R:
+                # 국경선 열어 연합에 추가
+                union.append((ny,nx))
+                visited[ny][nx] = True
+                dq.append((ny,nx))
+    return union
+
+cnt = 0
+while True:
+    visited = [[False]*N for _ in range(N)]
+    flag = False
+
+    for i in range(N):
+        for j in range(N):
+            if not visited[i][j]:
+                visited[i][j] = True
+                country = bfs(i,j) # 연합 리스트
+                
+                # 인구 이동
+                if len(country) > 1:
+                    flag = True
+                    num = sum([board[y][x] for y,x in country]) // len(country)
+                    for y, x in country: # 값 갱신
+                        board[y][x] = num
+    if not flag:
+        break
+    cnt += 1
+print(cnt)


### PR DESCRIPTION
📖 풀이한 문제
[이코테 Part3 2문제]

💡 문제에서 사용된 알고리즘
BFS, 정렬

📜 코드 설명
** 블록이동은 풀지 못했습니다. **

1. 국영수
- 입력받고 내림차순으로 정렬하고 싶은건 `lambda`를 통해 -를 붙여주면 된다.
- 국어 내림차순, 영어 오름차순, 수학내림차순, 이름 오름차순 우선순위로 정렬한다.

2. 인구 이동
- board에 지도 입력받기
- `checkValid`  : 주어진 맵 범위 안에 y,x좌표가 존재하는지 확인하는 함수
- bfs로 맵 범위안에 있고, 방문아직 안했고, 차이가 L이상 R이하라면 union 리스트에 추가 및 방문처리, dq추가
- bfs 함수 실행후 연합 국가(union)리스트를 반환하게 해서 국가 개수가 1이상이면, 인구 이동이 가능한 것이기에 `flag=True`로 지정해주고 board값을 합계/개수로 갱신 -> 인구이동 횟수 추가
- 인구이동이 불가능한 `flag=False`상태가 되면 끝낸다. 