### PR TITLE
[이코테/09] ByeongJun

### DIFF
--- a/CT-DongbinNa/ByeongJun/PART03/p355_DFS-BFS_Q22_블록 이동하기.py
+++ b/CT-DongbinNa/ByeongJun/PART03/p355_DFS-BFS_Q22_블록 이동하기.py
@@ -12,6 +12,7 @@ def solution(board):
     # (행1, 열1, 로봇이 놓인 방향)
     visited = set([(0, 0, 1)])
 
+
     while queue:
         r1, c1, robot_d, mv = queue.popleft()
         r2, c2 = r1 + drdc[robot_d][0], c1 + drdc[robot_d][1]


### PR DESCRIPTION
## 📖 풀이한 문제
1. 나동빈 이코테 353p 인구 이동
2. 나동빈 이코테 355p 블록 이동하기

## 💡 문제에서 사용된 알고리즘
1. DFS/BFS(인구 이동, 블록 이동하기)

## 📜 코드 설명
**1. 나동빈 이코테 353p 인구 이동**
- cnt는 인구 이동을 몇 번 진행했는지이며, move list에는 방향을 정의
- cand deque에서 나라 좌표를 하나씩 꺼내오고, 방문 여부 확인을 수행.(방문하지 않았으면 BFS 수행)
- 루프 종료 조건인 cand deque이 비어있는 경우(인구 이동 일어나지 않음)로 설정

**2. 나동빈 이코테 355p 블록 이동하기**
- 시간이 초과되었습니다. 맞는 아이디어를 떠올리기까지 시간이 걸렸습니다. 추후에 마저 풀어서 채점해보겠습니다!
- 답지 참조