### PR TITLE
[이코테/10] ChaeRim

### DIFF
--- a/CT-DongbinNa/ChaeRim/part3_실패율.py
+++ b/CT-DongbinNa/ChaeRim/part3_실패율.py
@@ -1,0 +1,23 @@
+from collections import deque
+def solution(N, stages):
+    answer = []
+    dic = dict()
+    stages.sort()
+    length = len(stages)
+    total = [0]*(N+2)
+    for i in stages:
+        total[i] += 1 # 1단계 실패 사람 1명, 2단계 실패 3명 ...
+    for i in range(1,N+1):
+        if length == 0:
+            dic[i] = 0
+            continue
+        dic[i] = total[i]/length
+        length -= total[i] # 전단계 실패 인원 제거
+
+    result = sorted(dic, key=lambda x: dic[x],reverse=True)
+    return result
+
+
+array = [2,1,2,6,2,4,3,3]
+print(solution(5,array))
+

--- a/CT-DongbinNa/ChaeRim/part3_안테나.py
+++ b/CT-DongbinNa/ChaeRim/part3_안테나.py
@@ -1,0 +1,9 @@
+import sys
+input = sys.stdin.readline
+
+n=int(input())
+li = list(map(int,input().split()))
+li.sort() # 1 5 7 9
+
+print(li[(n-1)//2])
+

--- a/CT-DongbinNa/ChaeRim/part3_카드 정렬하기.py
+++ b/CT-DongbinNa/ChaeRim/part3_카드 정렬하기.py
@@ -1,0 +1,18 @@
+import sys
+import heapq
+input = sys.stdin.readline
+
+hq = []
+total = 0
+n= int(input())
+for _ in range(n):
+    num = int(input())
+    heapq.heappush(hq,num)
+while len(hq) > 1:
+    a = heapq.heappop(hq)
+    b = heapq.heappop(hq)
+    c = a+b
+    total += c
+    heapq.heappush(hq,c)
+
+print(total)


### PR DESCRIPTION
📖 풀이한 문제
[이코테 Part3 2문제]

💡 문제에서 사용된 알고리즘
정렬

📜 코드 설명

1. 안테나
- 리스트 오름차순으로 정렬 후 중간값을 출력 하면 된다.

2. 카드 정렬하기
- 리스트로 풀면 시간복잡도에 걸리므로 `heap`를 사용한 최소 힙으로 푼다.
- 두개를 뽑아 c에 더하고 total에 누적합을 더한다. 
- c를 다시 힙큐에 넣기를 반복

3. 실패율
- 모두 다 비교하면 시간복잡도에 걸린다,
- total 이라는 배열에 각 단계 별 실패한 인원을 미리 저장해둔다. (결과에 쉽게 저장하려고)
- 첫 stages의 길이를 저장한다.
- 딕셔너리를 사용해서 실패인원/전체인원인 실패율을 value로 저장
- 전체 길이에선 실패한 사람 인원을 빼기
- 만약 이미 다 빼서 사람이 없으면 딕셔너리에 0 저장
- dic[x]로 value만 내림차순 정렬하여 새로운 result배열로 저장해 result 리턴